### PR TITLE
Update BrMaskModel

### DIFF
--- a/src/directives/br-mask.ts
+++ b/src/directives/br-mask.ts
@@ -2,21 +2,21 @@ import { Directive, ElementRef, Host, HostListener, Injectable, Input, OnInit, O
 import { AbstractControl, FormControl, FormGroupDirective } from '@angular/forms';
 
 export class BrMaskModel {
-  form: AbstractControl;
-  mask: string;
-  len: number;
-  person: boolean;
-  phone: boolean;
-  phoneNotDDD: boolean;
-  money: boolean;
-  percent: boolean;
-  type: 'alfa' | 'num' | 'all' = 'alfa';
-  decimal: number = 2;
-  decimalCaracter: string = `,`;
-  thousand: string;
-  userCaracters: boolean = false;
-  numberAndTousand: boolean = false;
-  moneyInitHasInt: boolean = true;
+  form?: AbstractControl;
+  mask?: string;
+  len?: number;
+  person?: boolean;
+  phone?: boolean;
+  phoneNotDDD?: boolean;
+  money?: boolean;
+  percent?: boolean;
+  type?: 'alfa' | 'num' | 'all' = 'alfa';
+  decimal?: number = 2;
+  decimalCaracter?: string = `,`;
+  thousand?: string;
+  userCaracters?: boolean = false;
+  numberAndTousand?: boolean = false;
+  moneyInitHasInt?: boolean = true;
 }
 
 @Directive({


### PR DESCRIPTION
Make all fields optional according to the docs.
This prevents editors displaying a warning like: "Type {type: string, mask: string} is not assignable to type BrMaskModel"